### PR TITLE
Fix display of Heisig comment and elements

### DIFF
--- a/_layouts/kanji-remain.html
+++ b/_layouts/kanji-remain.html
@@ -25,6 +25,21 @@ layout: default
 <h3>On-Yomi: <a>{{ page.on-yomi }}</a></h3>
 {% endif %}
 
+{% if page.elements %}
+<h2>Elements:</h2>
+<p>{{ page.elements }}</p>
+{% endif %}
+
+{% if page.heisig %}
+<h2>Heisig story:</h2>
+<p>{{ page.heisig }}</p>
+{% endif %}
+
+{% if page.commen %}
+<h2>Heisig comment:</h2>
+<p>{{ page.commen }}</p>
+{% endif %}
+
 {{ content }}
 
 <hr>

--- a/_layouts/kanji.html
+++ b/_layouts/kanji.html
@@ -32,11 +32,15 @@ layout: default
 
 <h3>On-Yomi: <a>{{ page.on-yomi }}</a> {% if page.kun-yomi %}— Kun-Yomi: <a>{{ page.kun-yomi }}</a>{% endif %}</h3>
 
+{% if page.elements %}
+  <h2>Elements:</h2>
+  <p>{{ page.elements }}</p>
+{% endif %}
 
-	{% if page.primit %}
-    <h2>Primitive:</h2>
-    <p>{{ page.primit }}</p>
-	{% endif %}
+{% if page.primit %}
+  <h2>Primitive:</h2>
+  <p>{{ page.primit }}</p>
+{% endif %}
 
   {% if page.heisig %}	
     <h2>Heisig story:</h2>


### PR DESCRIPTION
## Summary
- show each kanji's primitive elements
- include optional Heisig story and comment blocks on kanji pages

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890de23a9fc83338b1aef7ac98dfddf